### PR TITLE
Update 1.3.4

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,4 +1,8 @@
 {
+  "1.3.4": {
+    "en": "Fixed: heating on/off button (onoff.heating) was missing on existing devices after migration. Also ensures bestway_temp_reached and bestway_error_message capabilities are always present on existing devices.",
+    "de": "Behoben: Heizung Ein/Aus-Taste (onoff.heating) fehlte auf bestehenden Geräten nach der Migration. Stellt außerdem sicher, dass bestway_temp_reached und bestway_error_message immer vorhanden sind."
+  },
   "1.3.1": {
     "en": "Fixed: filter pump flow cards (on/off/changed triggers, conditions, actions) now also work for the Lay-Z-Spa Share Code driver. Fixed: spa error flow card now uses explicit driver filter. Fixed: capability order migration skips reorder when already correct. Added: pool filter flow card translations for 9 additional languages (no, cs, nl, da, sv, it, fr, ru, pl).",
     "de": "Behoben: Filterpumpen-Flow-Karten (Ein/Aus/Geändert-Trigger, Bedingungen, Aktionen) funktionieren jetzt auch für den Lay-Z-Spa Freigabecode-Treiber. Behoben: Spa-Fehler-Flow-Karte verwendet jetzt einen expliziten Treiber-Filter. Behoben: Capability-Reihenfolge-Migration überspringt die Neuordnung, wenn die Reihenfolge bereits korrekt ist. Hinzugefügt: Pool-Filter-Flow-Karten in 9 weiteren Sprachen (no, cs, nl, da, sv, it, fr, ru, pl)."

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.utkikk.layz",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [
@@ -54,7 +54,6 @@
       }
     ]
   },
-
   "author": {
     "name": "Ruben Torkelsen",
     "email": "layz@utkikk.com"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Control your **Bestway Lay-Z-Spa** (Airjet / Hydrojet Pro) and **Bestway Pool Fi
 | Temperature reached | Indicator when target temp is reached |
 | Power on/off | Turn the spa on or off |
 | Heating on/off | Control the heater |
-| Filter pump (Filtern) | Control the filter pump independently |
+| Filter pump | Control the filter pump independently |
 | Bubble / Wave (Airjet) | Toggle bubble massage |
 | Airjet Low / High (Hydrojet) | Two-level massage intensity |
 | Hydrojet Massage | Toggle the Hydrojet massage function |
@@ -51,11 +51,12 @@ Control your **Bestway Lay-Z-Spa** (Airjet / Hydrojet Pro) and **Bestway Pool Fi
 
 ## Flow Cards
 
-### Lay-Z-Spa
+### Lay-Z-Spa (Lay-Z & Share Code drivers)
 
 **Triggers**
-- Temperature reached
+- Temperature reached (token: temperature)
 - Error triggered (token: error message)
+- Filtering turned on / turned off / changed
 
 **Conditions**
 - Temperature is above / below threshold
@@ -63,6 +64,7 @@ Control your **Bestway Lay-Z-Spa** (Airjet / Hydrojet Pro) and **Bestway Pool Fi
 - Airjet is active
 - Error is active
 - Spa is locked
+- Filtering is on / off
 
 **Actions**
 - Set filter on/off
@@ -70,6 +72,7 @@ Control your **Bestway Lay-Z-Spa** (Airjet / Hydrojet Pro) and **Bestway Pool Fi
 - Set Airjet Low on/off
 - Set Airjet High on/off
 - Set Hydrojet on/off
+- Turn filter pump on / off / toggle
 
 ### Pool Filter Pump
 
@@ -83,19 +86,20 @@ Control your **Bestway Lay-Z-Spa** (Airjet / Hydrojet Pro) and **Bestway Pool Fi
 - Filter change is active
 - Error is active
 
-**Actions**
-- Turn filter pump on
-- Turn filter pump off
-- Toggle filter pump
-
 ---
 
 ## Pairing
 
+**Via account (Lay-Z driver):**
 1. Open the Homey app → **Devices** → **+** → search for **Lay-Z**
-2. Select the driver that matches your setup
+2. Select the **Lay-Z** driver
 3. Enter your **Bestway account credentials** (email + password)
 4. Select the device from the list and tap **Add**
+
+**Via share code (no account needed):**
+1. In the Bestway app: open your spa → Share → copy the share code
+2. In Homey: **Devices** → **+** → search for **Lay-Z** → select **Lay-Z-Spa (Share Code)**
+3. Enter the share code and tap **Add**
 
 To update credentials later (e.g. after a password change), long-press the device card → **Settings** → **Repair**.
 
@@ -114,6 +118,16 @@ The app supports 11 languages: English, German, Norwegian, Czech, Dutch, Danish,
 ---
 
 ## Changelog
+
+### 1.3.4
+- Fixed: heating on/off button missing on existing devices after capability migration
+- Fixed: `bestway_temp_reached` and `bestway_error_message` now always ensured present on existing devices
+
+### 1.3.1
+- Fixed: filter pump flow cards (on/off/changed triggers, conditions, actions) now also work for the Share Code driver
+- Fixed: spa error flow card now uses explicit driver filter
+- Fixed: capability order migration skips reorder when already correct
+- Added: pool filter flow card translations for 9 additional languages (no, cs, nl, da, sv, it, fr, ru, pl)
 
 ### 1.3.0
 - Added **Bestway Pool Filter Pump** driver with full flow card support

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.utkikk.layz",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "compatibility": ">=12.0.0",
   "sdk": 3,
   "platforms": [

--- a/drivers/Lay-Z/device.js
+++ b/drivers/Lay-Z/device.js
@@ -306,6 +306,7 @@ class SpaDevice extends Homey.Device {
 
     // *** Common capabilities (shared by all models) ****
     await this.enableCapability('onoff', this.getSetting('power_control_enabled'));
+    await this.enableCapability('onoff.heating', true);
     await this.enableCapability('pump_onoff', this.getSetting('filter_pump_control_enabled'));
     await this.enableCapability('pump_state', true);
     await this.enableCapability('heat_state', true);
@@ -313,6 +314,8 @@ class SpaDevice extends Homey.Device {
     await this.enableCapability('measure_power', true);
     await this.enableCapability('measure_temperature', true);
     await this.enableCapability('target_temperature', true);
+    await this.enableCapability('bestway_temp_reached', true);
+    await this.enableCapability('bestway_error_message', true);
     await this.enableCapability('alarm_generic', true);
   
     // *** Model-specific capabilities ***


### PR DESCRIPTION
onoff.heating was missing from the enableCapability block in onInit, so it wouldn't be added back on existing devices if it wasn't there already. Fixed in v1.3.4 along with bestway_temp_reached and bestway_error_message which had the same issue. A device restart after the update should restore the button.